### PR TITLE
fix: fix sql.insert_many

### DIFF
--- a/lab_scheduler/database/sql.py
+++ b/lab_scheduler/database/sql.py
@@ -65,10 +65,9 @@ class SQL:
         try:
             cursor.executemany(query, params_list)
             self.conn.commit()
-            inserted_ids = cursor.lastrowid
+            first_id = cursor.lastrowid
             num_rows = cursor.rowcount
-            first_id = inserted_ids - num_rows + 1
-            inserted_ids = list(range(first_id, inserted_ids + 1))
+            inserted_ids = list(range(first_id, first_id + num_rows))
         except Exception as e:
             self.conn.rollback()
             raise e
@@ -144,7 +143,7 @@ class SQL:
         return ret
 
     def get_object(self, query, params=()):
-        cursor = self.conn.cursor()
+        cursor = self.conn.cursor(buffered=True)
         cursor.execute(query, params)
         dados = cursor.fetchone()
         if dados is None:

--- a/lab_scheduler/database/sql.py
+++ b/lab_scheduler/database/sql.py
@@ -143,7 +143,7 @@ class SQL:
         return ret
 
     def get_object(self, query, params=()):
-        cursor = self.conn.cursor(buffered=True)
+        cursor = self.conn.cursor()
         cursor.execute(query, params)
         dados = cursor.fetchone()
         if dados is None:


### PR DESCRIPTION
## Motivation
The returned ids inserted are wrong, which is breaking associative table insertion.

## Solution
fix to return correct ids